### PR TITLE
Remove duplication on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,6 @@ directory or file to be linted.
 ./vendor/bin/xulieta check:error <directory>
 ```
 
-We also added an alias to the `check:erromeu` command, out of convenience for english speakers.
-
-```shell script
-./vendor/bin/xulieta check:error <directory>
-```
-
 ### Integration with GitHub Actions
 
 We provide out  of the box an  `output` format that you can  use to have


### PR DESCRIPTION
The command was duplicated to give an example of how to 
use the original command versus the version for English speakers.